### PR TITLE
[토너먼트] 기본 프로필 이미지 정상적으로 표기 수정 (#34)

### DIFF
--- a/src/components/tournament/TournamentHeader.jsx
+++ b/src/components/tournament/TournamentHeader.jsx
@@ -25,7 +25,7 @@ const TournamentHeader = ({ user }) => {
 					</div>
 				) : (
 					<span className="signed-in flex-column-center border-black">
-						<img src={user.profile_img} alt="user-img" />
+						<img src={user.profile_img ? user.profile_img : "/default-profile.svg"} alt="user-img" />
 					</span>
 				)}
 			</div>

--- a/src/components/tournament/TournamentUser.jsx
+++ b/src/components/tournament/TournamentUser.jsx
@@ -12,7 +12,7 @@ const TournamentUser = ({ player }) => {
 				</div>
 				<div className="profile-img flex-column-center">
 					<span id="profile-img">
-						<img src={player.profile_img ? player.profile_img : "%PUBLIC_URL%/default-profile.svg"} alt="profile-img" />
+						<img src={player.profile_img ? player.profile_img : "/default-profile.svg"} alt="profile-img" />
 					</span>
 				</div>
 				<div className="intra-id flex-column-center">


### PR DESCRIPTION
- 디폴트 이미지 로직 수정
- 헤더와 유저페이지 전부 동일하게 작동하도록 수정함

(#34)