### PR TITLE
[Fix] reservation response에 따른 메세지 수정, 고장접수페이지 헤더 z-idx 수정

### DIFF
--- a/src/components/Book.jsx
+++ b/src/components/Book.jsx
@@ -337,7 +337,6 @@ const BookActionWrapper = () => {
 	};
 
 	const onClickReservation = () => {
-		console.log(consoleType);
 		if (user.id === 0)
 			openModal(loginModal(loginModalAction));
 		else if (selects.s !== -1)

--- a/src/components/Book.jsx
+++ b/src/components/Book.jsx
@@ -19,6 +19,8 @@ import {
 	reserveTimeLimitError,
 	reserveSubmitError,
 	reserveSubmitHistoryTick,
+	reserveExceedsTime,
+	resrveTimeConflict,
 	failedReservationModal,
 	submitReservationSuccessModal,
 } from '../store/modal';
@@ -375,7 +377,10 @@ const BookActionWrapper = () => {
 			setSelects({ s: -1, e: -1 });
 			closeModal();
 			if (response.status === 400) {
-				openNoti(reserveSubmitError());
+				const error = await response.json();
+        		if (error.code === 1) openNoti(reserveExceedsTime());
+        		else if (error.code === 2) openNoti(resrveTimeConflict());
+       			else openNoti(reserveSubmitError());
 			} else
 				openModal(submitReservationSuccessModal(consoleType));
 		} catch (error) {

--- a/src/hooks/Auth.jsx
+++ b/src/hooks/Auth.jsx
@@ -71,7 +71,6 @@ const Auth = () => {
 					token.logout();
 				}
 			if (location.state) {
-				console.log(location.state);
 				navigate(location.state.from, { state: { from: location.pathname }});
 			} else {
 				console.log('navigate to index')

--- a/src/pages/report.jsx
+++ b/src/pages/report.jsx
@@ -63,7 +63,7 @@ const DeviceHeader = ({ page }) => {
 
 	return (
 		<>
-			<header className="w-full h-12 fixed flex flex-row items-center justify-between p-4 top-0 bg-white z-50">
+			<header className="w-full h-12 fixed flex flex-row items-center justify-between p-4 top-0 bg-white z-30">
 				<button id="menu-button" className="flex" onClick={onClickMenu}>
 					<svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />

--- a/src/store/modal.jsx
+++ b/src/store/modal.jsx
@@ -43,6 +43,18 @@ export const reserveSubmitError = () => {
 	});
 };
 
+export const resrveTimeConflict = () => {
+	return {
+	  content: '중복된 시간에 예약이 있습니다.',
+	};
+  };
+  
+export const reserveExceedsTime = () => {
+	return {
+	  content: '1시간을 초과해서 예약할 수 없습니다.',
+	};
+  };
+
 export const reserveSubmitHistoryTick = () => {
 	return ({
 		content: '지나간 시간은 예약 할 수 없습니다.'


### PR DESCRIPTION
# 고장접수페이지 z-index 수정
  고장접수페이지에서 드로어를 펼쳤을때, 헤더가 드로어보다 위로 올라오는 버그가 있었습니다.
 - 고장접수 z-index를 조정하여 수정하였습니다.
 - before
    
<img width="308" alt="스크린샷 2024-06-04 오후 9 16 14" src="https://github.com/Team-LV42/lv42-Frontend/assets/114637463/4021d710-f900-4512-b31c-d686f4144614">

 - after
  
<img width="318" alt="스크린샷 2024-06-04 오후 9 06 03" src="https://github.com/Team-LV42/lv42-Frontend/assets/114637463/98af2bd0-acf9-4e8a-ac22-2b1454222b52">


# 예약실패 경우에 따라 토스트 메세지 수정
  - 로그인 이후 예약실패하는 경우는 일반적으로 두가지가 있습니다.
     -  이미 해당시간에 예약이 되어있는 경우 (중복된 예약)
     -  예약한 시간이 총 1시간을 넘어 있는 경우
     -  그 외 기타 상황
   - 따라서, 이전에 예약실패로 통일되어있던 안내문구를 상황에 따라 다르게 안내하도록 수정하였습니다.
   - 에약실패했을 시 error.status는 모두 400으로 오게됩니다.
     - 이때 response 내용에 따라 분기하여 안내모달을 띄웁니다.
     - 이미 해당시간에 예약이 되어있는 경우 (중복된 예약) : 응답코드 1
     - 예약한 시간이 총 1시간을 넘어 있는 경우 : 응답코드 2
     - 그 외 기타 예상하지 못한 상황에는 예약실패로 통일하여 안내합니다.
   
<img width="318" alt="스크린샷 2024-06-04 오후 9 06 03" src="https://github.com/Team-LV42/lv42-Frontend/assets/114637463/8ded79ec-5185-4c58-9dba-b5dee3c29f53">


# 콘솔로그 삭제
- 의미없어보이는 console.log() 삭제하였습니다.

#125 
